### PR TITLE
Add "named group" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ Fork of [Memory Bag 2.0](https://steamcommunity.com/sharedfiles/filedetails/?id=
 * Move relative to one object
 * Set New based on table position
 * Dragable selection setup and add (thanks cowgoesmoo33)
+* Groups where only one can be placed at a time (thanks Quickle)
 
 Want to contribute? Create an issue or fork the code on GitHub and submit a pull request.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Fork of [Memory Bag 2.0](https://steamcommunity.com/sharedfiles/filedetails/?id=
 * Move relative to one object
 * Set New based on table position
 * Dragable selection setup and add (thanks cowgoesmoo33)
-* Groups where only one can be placed at a time (thanks Quickle)
+* Named groups where only one bag can be placed at a time (thanks Quickle)
 
 Want to contribute? Create an issue or fork the code on GitHub and submit a pull request.

--- a/UtilityMemoryBag.lua
+++ b/UtilityMemoryBag.lua
@@ -42,25 +42,18 @@ function memoryGroupName:set(newName)
     end
 end
 
-
 -- Click the "Recall" button on all other bags in my memory group.
 function recallOtherBagsInMyGroup()
-    for bagGuid,_ in pairs(GlobalMemoryGroups:getGroup(memoryGroupName:get())) do
-        if bagGuid ~= self.getGUID() then
-            bag = getObjectFromGUID(bagGuid)
-            bag.call('buttonClick_recall')
-        end
+    for _,bag in ipairs(getOtherBagsInMyGroup()) do
+        bag.call('buttonClick_recall')
     end
 end
 
 -- Return "true" if another bag in my memory group has any objects out on the table.
 function anyOtherBagsInMyGroupArePlaced()
-    for bagGuid,_ in pairs(GlobalMemoryGroups:getGroup(memoryGroupName:get())) do
-        if bagGuid ~= self.getGUID() then
-            local bag = getObjectFromGUID(bagGuid)
-            local state = bag.call('areAnyOfMyObjectsPlaced')
-            if state then return true end
-        end
+    for _,bag in ipairs(getOtherBagsInMyGroup()) do
+        local state = bag.call('areAnyOfMyObjectsPlaced')
+        if state then return true end
     end
 
     return false
@@ -75,6 +68,20 @@ function areAnyOfMyObjectsPlaced()
         end
     end
     return false
+end
+
+function getOtherBagsInMyGroup()
+    local bags = {}
+    for bagGuid,_ in pairs(GlobalMemoryGroups:getGroup(memoryGroupName:get())) do
+        if bagGuid ~= self.getGUID() then
+            bag = getObjectFromGUID(bagGuid)
+            -- "bag" is nill if it has been deleted since the last time onLoad() was called.
+            if bag ~= nil then
+                table.insert(bags, bag)
+            end
+        end
+    end
+    return bags
 end
 
 

--- a/UtilityMemoryBag.lua
+++ b/UtilityMemoryBag.lua
@@ -191,6 +191,7 @@ function onload(saved_data)
     end
 
     GlobalMemoryGroups:onLoad(self.getGUID())
+    AllMemoryBagsInScene:add(self.getGUID())
 end
 
 
@@ -680,4 +681,26 @@ end
 function round(num, dec)
     local mult = 10^(dec or 0)
     return math.floor(num * mult + 0.5) / mult
+end
+
+
+--[[
+This object provides access to a variable stored on the "Global script".
+The variable holds the GUIDs for every Utility Memory Bag in the scene.
+
+Example:
+{'805ebd', '35cc21', 'fc8886', 'f50264', '5f5f63'}
+--]]
+AllMemoryBagsInScene = {
+    NAME_OF_GLOBAL_VARIABLE = "_UtilityMemoryBag_AllMemoryBagsInScene"
+}
+
+function AllMemoryBagsInScene:add(guid)
+    local guids = Global.getTable(self.NAME_OF_GLOBAL_VARIABLE) or {}
+    table.insert(guids, guid)
+    Global.setTable(self.NAME_OF_GLOBAL_VARIABLE, guids)
+end
+
+function AllMemoryBagsInScene:getGuidList()
+    return Global.getTable(self.NAME_OF_GLOBAL_VARIABLE) or {}
 end

--- a/UtilityMemoryBag.lua
+++ b/UtilityMemoryBag.lua
@@ -17,9 +17,9 @@ CONFIG = {
 
 --[[ Memory Bag Groups ]]-------------------------------------------------------
 --[[
-Utility Memory Bags may be added to a named group, called the "memory group".
+Utility Memory Bags may be added to a named group, called a "memory group".
 
-You can add a bag to a group through the bag's UI: "Setup" > "Group Name" (to left of the bag).
+You can add a bag to a group through the bag's UI: "Setup" > "Group Name" (to the left of the bag).
 
 Only one bag from a group may have it's contents placed on the table at a time.
 When "Place" is clicked on a bag, the other bags in it's memory group are recalled.
@@ -158,7 +158,6 @@ end
 -- This object controls the "Group Name" input text field that is part of the bag's ingame UI.
 groupNameInput = {
     greyedOutText = "Group Name",
-    -- widthPerCharacter = 133.33333,
     widthPerCharacter = 100,
     padding = 4,
     memoryBag=self,

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
     "result": {
-        "utilityMemoryBag": "2.6.0"
+        "utilityMemoryBag": "2.7.0"
     }
 }


### PR DESCRIPTION
## New Feature
This feature allows the user to optionally associate each Utility Memory Bag with a named group (ex: "Blue Player Factions"). For each named group, only one bag may have it's objects placed at a time. Whenever objects are placed from a bag, it first recalls all other bags in it's named group.

This feature was inspired by the [Memory Bag Groups mod](https://steamcommunity.com/sharedfiles/filedetails/?id=1090295747).

I wrote my own version of the code from scratch and with some improvements:
* The user doesn't need to manually modify the Global script. The Utility Memory Bag takes care of that for you.
* The code for this feature is self contained and object oriented.

## Testing
I've been using this code since August 2019 in my [Advanced Space Crusade mod](https://steamcommunity.com/sharedfiles/filedetails/?id=1848337677). I tested the code extensively at that time, but I don't remember the exact tests. I cleaned up the code a bit for this pull request and did some quick testing for the cleaner code.

## Using the Feature
To associate a Utility Memory Bag with a named group, change the value on line 9 of the script (i.e. `CONFIG.MEMORY_GROUP.NAME`).

I'll add a UI text box for this feature in 1-2 days (see below). That way users don't need scripting skills to use this feature.

## Follow Up
Please don't merge in this pull request yet.

I have a couple more things I want to do. I ran out of time tonight, and will finish this PR within 1-2 days.

Remaining tasks:
* Add UI for this feature (ex: a text box / button).
* Extensive testing. Even though I'm confident with my tests from Aug 2019, I'd like to do my due diligence again to test this feature.